### PR TITLE
fix(withdrawal lock): wrong custodian lock args parse when revert

### DIFF
--- a/contracts/withdrawal-lock/src/entry.rs
+++ b/contracts/withdrawal-lock/src/entry.rs
@@ -114,8 +114,8 @@ pub fn main() -> Result<(), Error> {
                     let custodian_lock = load_cell_lock(custodian_cell_index, Source::Output)?;
                     let custodian_lock_args = {
                         let args: Bytes = custodian_lock.args().unpack();
-                        match CustodianLockArgsReader::verify(&args, false) {
-                            Ok(_) => CustodianLockArgs::new_unchecked(args),
+                        match CustodianLockArgsReader::verify(&args.slice(32..), false) {
+                            Ok(_) => CustodianLockArgs::new_unchecked(args.slice(32..)),
                             Err(_) => return Err(Error::InvalidOutput),
                         }
                     };

--- a/contracts/withdrawal-lock/src/entry.rs
+++ b/contracts/withdrawal-lock/src/entry.rs
@@ -114,6 +114,13 @@ pub fn main() -> Result<(), Error> {
                     let custodian_lock = load_cell_lock(custodian_cell_index, Source::Output)?;
                     let custodian_lock_args = {
                         let args: Bytes = custodian_lock.args().unpack();
+                        if args.len() < rollup_type_hash.len() {
+                            return Err(Error::InvalidArgs);
+                        }
+                        if &args[..32] != rollup_type_hash {
+                            return Err(Error::InvalidArgs);
+                        }
+
                         match CustodianLockArgsReader::verify(&args.slice(32..), false) {
                             Ok(_) => CustodianLockArgs::new_unchecked(args.slice(32..)),
                             Err(_) => return Err(Error::InvalidOutput),

--- a/contracts/withdrawal-lock/src/entry.rs
+++ b/contracts/withdrawal-lock/src/entry.rs
@@ -117,7 +117,7 @@ pub fn main() -> Result<(), Error> {
                         if args.len() < rollup_type_hash.len() {
                             return Err(Error::InvalidArgs);
                         }
-                        if &args[..32] != rollup_type_hash {
+                        if args[..32] != rollup_type_hash {
                             return Err(Error::InvalidArgs);
                         }
 


### PR DESCRIPTION
First 32 bytes should be rollup type hash