### PR TITLE
Support consume challenge cell without update rollup status

### DIFF
--- a/c/validator_utils.h
+++ b/c/validator_utils.h
@@ -1082,6 +1082,7 @@ int gw_context_init(gw_context_t *ctx) {
   if (ret != 0) {
     return ret;
   }
+
   /* setup syscalls */
   ctx->sys_load = sys_load;
   ctx->sys_load_nonce = sys_load_nonce;
@@ -1111,7 +1112,11 @@ int gw_context_init(gw_context_t *ctx) {
   uint64_t rollup_cell_index = 0;
   ret = _find_cell_by_type_hash(rollup_script_hash, CKB_SOURCE_INPUT,
                                 &rollup_cell_index);
-  if (ret != 0) {
+  if (ret == CKB_INDEX_OUT_OF_BOUND) {
+    /* exit execution with 0 if we are not in a challenge */
+    ckb_debug("can't found rollup cell from inputs which means we are not in a challenge, unlock cell without execution script");
+    ckb_exit(0);
+  } else if (ret != 0) {
     ckb_debug("failed to load rollup cell index");
     return ret;
   }

--- a/tests/src/script_tests/account_lock_scripts/eth_account_lock.rs
+++ b/tests/src/script_tests/account_lock_scripts/eth_account_lock.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::testing_tool::ETH_ACCOUNT_LOCK_PROGRAM;
 use crate::script_tests::utils::layer1::*;
 use ckb_crypto::secp::{Generator, Privkey, Pubkey};
 use ckb_error::assert_error_eq;
@@ -15,12 +16,6 @@ use sha3::{Digest, Keccak256};
 
 const ERROR_PUBKEY_BLAKE160_HASH: i8 = -31;
 
-lazy_static! {
-    pub static ref ETH_ACCOUNT_LOCK: Bytes = Bytes::from(
-        &include_bytes!("../../../../../godwoken-scripts/c/build/account_locks/eth-account-lock")[..]
-    );
-}
-
 fn gen_tx(dummy: &mut DummyDataLoader, lock_args: Bytes, input_data: Bytes) -> TransactionView {
     let mut rng = thread_rng();
     // setup sighash_all dep
@@ -35,15 +30,15 @@ fn gen_tx(dummy: &mut DummyDataLoader, lock_args: Bytes, input_data: Bytes) -> T
     // dep contract code
     let script_cell = CellOutput::new_builder()
         .capacity(
-            Capacity::bytes(ETH_ACCOUNT_LOCK.len())
+            Capacity::bytes(ETH_ACCOUNT_LOCK_PROGRAM.len())
                 .expect("script capacity")
                 .pack(),
         )
         .build();
-    let script_cell_data_hash = CellOutput::calc_data_hash(&ETH_ACCOUNT_LOCK);
+    let script_cell_data_hash = CellOutput::calc_data_hash(&ETH_ACCOUNT_LOCK_PROGRAM);
     dummy.cells.insert(
         script_out_point.clone(),
-        (script_cell, ETH_ACCOUNT_LOCK.clone()),
+        (script_cell, ETH_ACCOUNT_LOCK_PROGRAM.clone()),
     );
     // setup secp256k1_data dep
     let secp256k1_data_out_point = {

--- a/tests/src/script_tests/l2_scripts/meta_contract.rs
+++ b/tests/src/script_tests/l2_scripts/meta_contract.rs
@@ -1,6 +1,5 @@
 use super::{new_block_info, run_contract};
 use crate::testing_tool::chain::META_VALIDATOR_SCRIPT_TYPE_HASH;
-use ckb_types::bytes::Bytes;
 use core::panic;
 use gw_common::state::State;
 use gw_common::H256;
@@ -13,13 +12,6 @@ use gw_types::{
     packed::{CreateAccount, MetaContractArgs, RollupConfig, Script},
     prelude::*,
 };
-use lazy_static::lazy_static;
-
-lazy_static! {
-    pub static ref ETH_ACCOUNT_LOCK: Bytes = Bytes::from(
-        &include_bytes!("../../../../../godwoken-scripts/c/build/meta-contract-validator")[..]
-    );
-}
 
 #[test]
 fn test_meta_contract() {

--- a/tests/src/script_tests/l2_scripts_validator/consume_challenge_resolve_cell.rs
+++ b/tests/src/script_tests/l2_scripts_validator/consume_challenge_resolve_cell.rs
@@ -1,0 +1,101 @@
+//! This module test consume challenge-resolve cells without challenge context
+//!
+//! Because of anyone can send challenge-resolve context to resolve a challenge,
+//! once the challenge gets resolved, others need to be able to consume thier
+//! challenge resolve cell and get CKB back.
+
+use crate::script_tests::utils::layer1::build_resolved_tx;
+use crate::script_tests::utils::layer1::build_simple_tx_with_out_point;
+use crate::script_tests::utils::layer1::random_out_point;
+use crate::script_tests::utils::layer1::DummyDataLoader;
+use crate::script_tests::utils::layer1::MAX_CYCLES;
+use ckb_script::TransactionScriptsVerifier;
+use ckb_types::packed::CellDep;
+use ckb_types::{
+    packed::{CellInput, CellOutput},
+    prelude::{Pack as CKBPack, Unpack},
+};
+use gw_types::bytes::Bytes;
+use gw_types::prelude::*;
+
+use crate::testing_tool::programs::{
+    ALWAYS_SUCCESS_CODE_HASH, ALWAYS_SUCCESS_PROGRAM, META_CONTRACT_CODE_HASH,
+    META_CONTRACT_VALIDATOR_PROGRAM,
+};
+
+#[test]
+fn test_consume_challenge_resolve_cell() {
+    // deploy scripts
+    let mut ctx = DummyDataLoader::default();
+    let script_out_point = random_out_point();
+    ctx.cells.insert(
+        script_out_point.clone(),
+        (
+            CellOutput::default(),
+            META_CONTRACT_VALIDATOR_PROGRAM.clone(),
+        ),
+    );
+
+    let lock_out_point = random_out_point();
+    ctx.cells.insert(
+        lock_out_point.clone(),
+        (CellOutput::default(), ALWAYS_SUCCESS_PROGRAM.clone()),
+    );
+
+    let (owner_lock_out_point, owner_lock_hash) = {
+        let cell = CellOutput::new_builder()
+            .lock(
+                ckb_types::packed::Script::new_builder()
+                    .code_hash(CKBPack::pack(&*ALWAYS_SUCCESS_CODE_HASH))
+                    .hash_type(ckb_types::core::ScriptHashType::Data.into())
+                    .build(),
+            )
+            .capacity(CKBPack::pack(&42u64))
+            .build();
+        let owner_lock_hash: [u8; 32] = cell.lock().calc_script_hash().unpack();
+        let owner_lock_out_point = random_out_point();
+        ctx.cells
+            .insert(owner_lock_out_point.clone(), (cell, Bytes::default()));
+        (owner_lock_out_point, owner_lock_hash)
+    };
+
+    let (challenge_resolve_cell, data) = {
+        // mocked rollup script hash
+        let rollup_script_hash = [42u8; 32];
+        let args = Bytes::from(rollup_script_hash.to_vec());
+        let cell = CellOutput::new_builder()
+            .lock(
+                ckb_types::packed::Script::new_builder()
+                    .code_hash(CKBPack::pack(&*META_CONTRACT_CODE_HASH))
+                    .hash_type(ckb_types::core::ScriptHashType::Data.into())
+                    .args(CKBPack::pack(&args))
+                    .build(),
+            )
+            .capacity(CKBPack::pack(&42u64))
+            .build();
+        (cell, Bytes::from(owner_lock_hash.to_vec()))
+    };
+    let challenge_resolved_out_point = random_out_point();
+
+    let tx = build_simple_tx_with_out_point(
+        &mut ctx,
+        (challenge_resolve_cell.clone(), data),
+        challenge_resolved_out_point,
+        (CellOutput::default(), Bytes::default()),
+    )
+    .as_advanced_builder()
+    .witness(CKBPack::pack(&Bytes::default()))
+    .input(
+        CellInput::new_builder()
+            .previous_output(owner_lock_out_point)
+            .build(),
+    )
+    .witness(CKBPack::pack(&Bytes::default()))
+    .cell_dep(CellDep::new_builder().out_point(script_out_point).build())
+    .cell_dep(CellDep::new_builder().out_point(lock_out_point).build())
+    .build();
+    let resolved_tx = build_resolved_tx(&ctx, &tx);
+    let mut verifier = TransactionScriptsVerifier::new(&resolved_tx, &ctx);
+    verifier.set_debug_printer(|_script, msg| println!("[script debug] {}", msg));
+    verifier.verify(MAX_CYCLES).expect("success");
+}

--- a/tests/src/script_tests/l2_scripts_validator/mod.rs
+++ b/tests/src/script_tests/l2_scripts_validator/mod.rs
@@ -1,0 +1,1 @@
+mod consume_challenge_resolve_cell;

--- a/tests/src/script_tests/mod.rs
+++ b/tests/src/script_tests/mod.rs
@@ -1,4 +1,5 @@
 mod account_lock_scripts;
 mod l2_scripts;
+mod l2_scripts_validator;
 mod state_validator;
 pub mod utils;

--- a/tests/src/testing_tool/programs.rs
+++ b/tests/src/testing_tool/programs.rs
@@ -10,6 +10,8 @@ const STATE_VALIDATOR: &'static str = "state-validator";
 const ALWAYS_SUCCESS_PATH: &'static str = "always-success";
 const ETH_LOCK_PATH: &'static str = "eth-account-lock";
 const SECP256K1_DATA_PATH: &'static str = "../c/deps/ckb-production-scripts/build/secp256k1_data";
+const C_SCRIPTS_DIR: &'static str = "../../godwoken-scripts/c/build";
+const META_CONTRACT_BIN_NAME: &'static str = "meta-contract-validator";
 
 lazy_static! {
     pub static ref ALWAYS_SUCCESS_PROGRAM: Bytes = {
@@ -86,6 +88,22 @@ lazy_static! {
         let mut buf = [0u8; 32];
         let mut hasher = new_blake2b();
         hasher.update(&SECP256K1_DATA);
+        hasher.finalize(&mut buf);
+        buf
+    };
+    pub static ref META_CONTRACT_VALIDATOR_PROGRAM: Bytes = {
+        let mut buf = Vec::new();
+        let mut path = PathBuf::new();
+        path.push(&C_SCRIPTS_DIR);
+        path.push(&META_CONTRACT_BIN_NAME);
+        let mut f = fs::File::open(&path).expect("load program");
+        f.read_to_end(&mut buf).expect("read program");
+        Bytes::from(buf.to_vec())
+    };
+    pub static ref META_CONTRACT_CODE_HASH: [u8; 32] = {
+        let mut buf = [0u8; 32];
+        let mut hasher = new_blake2b();
+        hasher.update(&META_CONTRACT_VALIDATOR_PROGRAM);
         hasher.finalize(&mut buf);
         buf
     };


### PR DESCRIPTION
 Because of anyone can send challenge-resolve context to resolve a challenge, once the challenge gets resolved, others need to be able to consume thier challenge resolve cell and get CKB back.