### PR TITLE
Fix misaligned address

### DIFF
--- a/c/common.h
+++ b/c/common.h
@@ -95,8 +95,8 @@ int gw_parse_block_info(gw_block_info_t *block_info, mol_seg_t *src) {
   mol_seg_t number_seg = MolReader_BlockInfo_get_number(src);
   mol_seg_t timestamp_seg = MolReader_BlockInfo_get_timestamp(src);
   mol_seg_t block_producer_id_seg = MolReader_BlockInfo_get_block_producer_id(src);
-  block_info->number = *(uint64_t *)number_seg.ptr;
-  block_info->timestamp = *(uint64_t *)timestamp_seg.ptr;
+  memcpy(&block_info->number, number_seg.ptr, sizeof(uint64_t));
+  memcpy(&block_info->timestamp, timestamp_seg.ptr, sizeof(uint64_t));
   block_info->block_producer_id = *(uint32_t *)block_producer_id_seg.ptr;
   return 0;
 }


### PR DESCRIPTION
undefined-behavior: load of misaligned address:
> runtime error: load of misaligned address 0x7fff0cdc6264 for type 'uint64_t' (aka 'unsigned long'), which requires 8 byte alignment
0x7fff0cdc6264: note: pointer points here

detected by [UndefinedBehaviorSanitizer](https://github.com/nervosnetwork/godwoken-internal/issues/60)

