### PR TITLE
Avoid memory allocating

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "gw-common"
 version = "0.1.0"
-source = "git+https://github.com/nervosnetwork/godwoken.git?rev=5070f2d32c60d1a5953742a38ac618e57656a41c#5070f2d32c60d1a5953742a38ac618e57656a41c"
+source = "git+https://github.com/nervosnetwork/godwoken.git?rev=aeb5a94f8c9bb3642fd1ee5e794ad61a77a54c29#aeb5a94f8c9bb3642fd1ee5e794ad61a77a54c29"
 dependencies = [
  "cfg-if",
  "gw-hash",
@@ -140,7 +140,7 @@ dependencies = [
 [[package]]
 name = "gw-hash"
 version = "0.1.0"
-source = "git+https://github.com/nervosnetwork/godwoken.git?rev=5070f2d32c60d1a5953742a38ac618e57656a41c#5070f2d32c60d1a5953742a38ac618e57656a41c"
+source = "git+https://github.com/nervosnetwork/godwoken.git?rev=aeb5a94f8c9bb3642fd1ee5e794ad61a77a54c29#aeb5a94f8c9bb3642fd1ee5e794ad61a77a54c29"
 dependencies = [
  "blake2b-ref",
 ]
@@ -148,7 +148,7 @@ dependencies = [
 [[package]]
 name = "gw-types"
 version = "0.1.0"
-source = "git+https://github.com/nervosnetwork/godwoken.git?rev=5070f2d32c60d1a5953742a38ac618e57656a41c#5070f2d32c60d1a5953742a38ac618e57656a41c"
+source = "git+https://github.com/nervosnetwork/godwoken.git?rev=aeb5a94f8c9bb3642fd1ee5e794ad61a77a54c29#aeb5a94f8c9bb3642fd1ee5e794ad61a77a54c29"
 dependencies = [
  "cfg-if",
  "gw-hash",

--- a/contracts/challenge-lock/src/verifications/tx_execution.rs
+++ b/contracts/challenge-lock/src/verifications/tx_execution.rs
@@ -36,7 +36,7 @@ pub fn verify_tx_execution(
     let ctx = unlock_args.context();
     let tx = unlock_args.l2tx();
     let kv_state = KVState::new(
-        ctx.kv_state(),
+        ctx.kv_state().as_reader(),
         unlock_args.kv_state_proof().unpack(),
         ctx.account_count().unpack(),
         None,

--- a/contracts/challenge-lock/src/verifications/tx_signature.rs
+++ b/contracts/challenge-lock/src/verifications/tx_signature.rs
@@ -63,7 +63,7 @@ pub fn verify_tx_signature(
     let tx = unlock_args.l2tx();
     let account_count: u32 = ctx.account_count().unpack();
     let kv_state = KVState::new(
-        ctx.kv_state(),
+        ctx.kv_state().as_reader(),
         unlock_args.kv_state_proof().unpack(),
         account_count,
         None,

--- a/contracts/state-validator/src/verifications/challenge.rs
+++ b/contracts/state-validator/src/verifications/challenge.rs
@@ -49,7 +49,7 @@ pub fn verify_enter_challenge(
         let merkle_proof = CompiledMerkleProof(witness.block_proof().unpack());
         let leaves = vec![(
             RawL2Block::compute_smt_key(challenged_block.number().unpack()).into(),
-            challenged_block.to_entity().hash().into(),
+            challenged_block.hash().into(),
         )];
         merkle_proof
             .verify::<Blake2bHasher>(&prev_global_state.block().merkle_root().unpack(), leaves)?
@@ -60,7 +60,7 @@ pub fn verify_enter_challenge(
     }
     let challenge_target = challenge_cell.args.target();
     let challenged_block_hash: [u8; 32] = challenge_target.block_hash().unpack();
-    if challenged_block.to_entity().hash() != challenged_block_hash {
+    if challenged_block.hash() != challenged_block_hash {
         return Err(Error::InvalidChallengeTarget);
     }
     let target_type: ChallengeTargetType = challenge_target

--- a/contracts/state-validator/src/verifications/revert.rs
+++ b/contracts/state-validator/src/verifications/revert.rs
@@ -160,17 +160,15 @@ fn check_reverted_blocks(
     if reverted_blocks.is_empty() {
         return Err(Error::InvalidRevertedBlocks);
     }
-    let reverted_block_hashes: Vec<H256> = reverted_blocks
-        .iter()
-        .map(|b| b.to_entity().hash().into())
-        .collect();
+    let reverted_block_hashes: Vec<H256> =
+        reverted_blocks.iter().map(|b| b.hash().into()).collect();
     let reverted_block_smt_keys: Vec<H256> = reverted_blocks
         .iter()
         .map(|b| RawL2Block::compute_smt_key(b.number().unpack()).into())
         .collect();
     // check reverted_blocks is continues
     {
-        let mut prev_hash: Byte32 = reverted_blocks[0].to_entity().hash().pack();
+        let mut prev_hash: Byte32 = reverted_blocks[0].hash().pack();
         let mut prev_number = reverted_blocks[0].number().unpack();
         for b in reverted_blocks[1..].iter() {
             let hash = b.parent_block_hash();
@@ -304,7 +302,7 @@ pub fn verify(
         &rollup_type_hash,
         config,
         &challenge_cell,
-        &challenged_block.to_entity().hash().into(),
+        &challenged_block.hash().into(),
     )?;
     check_rewards(&rollup_type_hash, config, &reverted_blocks, &challenge_cell)?;
     let reverted_global_state = check_reverted_blocks(

--- a/contracts/state-validator/src/verifications/submit_block.rs
+++ b/contracts/state-validator/src/verifications/submit_block.rs
@@ -389,7 +389,7 @@ fn load_block_context_and_state(
     }
 
     let post_block_root: [u8; 32] = post_global_state.block().merkle_root().unpack();
-    let block_hash: H256 = raw_block.to_entity().hash().into();
+    let block_hash: H256 = raw_block.hash().into();
     if !block_merkle_proof
         .verify::<Blake2bHasher>(
             &post_block_root.into(),
@@ -548,7 +548,7 @@ fn check_block_transactions(block: &L2BlockReader, kv_state: &KVState) -> Result
     let leaves = block
         .transactions()
         .iter()
-        .map(|tx| tx.to_entity().witness_hash().into())
+        .map(|tx| tx.witness_hash().into())
         .collect();
     let merkle_root: H256 = calculate_merkle_root(leaves)?;
     if tx_witness_root != merkle_root {
@@ -607,7 +607,7 @@ fn check_block_withdrawals(block: &L2BlockReader) -> Result<(), Error> {
     let leaves = block
         .withdrawals()
         .iter()
-        .map(|withdrawal| withdrawal.to_entity().witness_hash().into())
+        .map(|withdrawal| withdrawal.witness_hash().into())
         .collect();
     let merkle_root = calculate_merkle_root(leaves)?;
     if withdrawal_witness_root != merkle_root {

--- a/contracts/validator-utils/Cargo.toml
+++ b/contracts/validator-utils/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 
 [dependencies]
 ckb-std = "0.7.4"
-gw-types = { git = "https://github.com/nervosnetwork/godwoken.git", rev = "5070f2d32c60d1a5953742a38ac618e57656a41c", default-features = false }
-gw-common = { git = "https://github.com/nervosnetwork/godwoken.git", rev = "5070f2d32c60d1a5953742a38ac618e57656a41c", default-features = false }
+gw-types = { git = "https://github.com/nervosnetwork/godwoken.git", rev = "aeb5a94f8c9bb3642fd1ee5e794ad61a77a54c29", default-features = false }
+gw-common = { git = "https://github.com/nervosnetwork/godwoken.git", rev = "aeb5a94f8c9bb3642fd1ee5e794ad61a77a54c29", default-features = false }

--- a/contracts/validator-utils/src/cells/lock_cells.rs
+++ b/contracts/validator-utils/src/cells/lock_cells.rs
@@ -20,7 +20,7 @@ use gw_types::{
     bytes::Bytes,
     core::ScriptHashType,
     packed::{
-        Byte32, DepositLockArgs, RollupConfig, StakeLockArgs, WithdrawalLockArgs,
+        Byte32, Byte32Reader, DepositLockArgs, RollupConfig, StakeLockArgs, WithdrawalLockArgs,
         WithdrawalLockArgsReader,
     },
     prelude::*,
@@ -139,7 +139,7 @@ pub fn find_block_producer_stake_cell(
     rollup_type_hash: &H256,
     config: &RollupConfig,
     source: Source,
-    owner_lock_hash: &Byte32,
+    owner_lock_hash: &Byte32Reader,
 ) -> Result<Option<StakeCell>, Error> {
     let mut cells = collect_stake_cells(rollup_type_hash, config, source)?;
     // return an error if more than one stake cell returned
@@ -153,7 +153,7 @@ pub fn find_block_producer_stake_cell(
     }
     if cells
         .iter()
-        .any(|cell| &cell.args.owner_lock_hash() != owner_lock_hash)
+        .any(|cell| cell.args.owner_lock_hash().as_slice() != owner_lock_hash.as_slice())
     {
         debug!("found stake cell with unexpected owner_lock_hash");
         return Err(Error::InvalidStakeCell);

--- a/contracts/validator-utils/src/kv_state.rs
+++ b/contracts/validator-utils/src/kv_state.rs
@@ -1,7 +1,7 @@
 use alloc::collections::BTreeMap;
 use ckb_std::debug;
 use gw_common::{error::Error, smt::Blake2bHasher, smt::CompiledMerkleProof, state::State, H256};
-use gw_types::{bytes::Bytes, packed::KVPairVec, prelude::*};
+use gw_types::{bytes::Bytes, packed::KVPairVecReader, prelude::*};
 
 pub struct KVState {
     kv: BTreeMap<H256, H256>,
@@ -17,16 +17,13 @@ impl KVState {
     /// - account count, account count in the current state
     /// - current_root, calculate_root returns this value if the kv_paris & proof is empty
     pub fn new(
-        kv_pairs: KVPairVec,
+        kv_pairs: KVPairVecReader,
         proof: Bytes,
         account_count: u32,
         current_root: Option<H256>,
     ) -> Self {
         KVState {
-            kv: kv_pairs
-                .into_iter()
-                .map(|kv_pair| kv_pair.unpack())
-                .collect(),
+            kv: kv_pairs.iter().map(|kv_pair| kv_pair.unpack()).collect(),
             proof,
             account_count,
             previous_root: current_root,


### PR DESCRIPTION
state-validator crashes when witness is too large, the reason is the default globall allocator uses buddy-allocator, the memory block of the buddy-allocator can't satisfied the witness size.

So, we use a large array to receive witness, and use molecule reader structures to reference to the data. This change should also reduces cycles cost by contracts.