### PR TITLE
Leave nonce to brackend vms

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -28,7 +28,13 @@ debug-all-via-docker: generate-protocol $(SECP256K1_HELPER)
 
 all: $(BINS)
 
-clean:
+clean-examples:
+	rm -f build/examples/*.debug
+	rm -f build/examples/*.h
+	rm -f build/examples/*.o
+	rm -f build/examples/*.a
+
+clean: clean-examples
 	rm -f $(BINS)
 	rm -f build/*.debug
 	rm -f build/*.h

--- a/c/gw_def.h
+++ b/c/gw_def.h
@@ -250,4 +250,30 @@ typedef int (*gw_log_fn)(struct gw_context_t *ctx, uint32_t account_id, uint8_t 
 typedef int (*gw_pay_fee_fn)(struct gw_context_t *ctx, const uint8_t *payer_addr,
                              const uint64_t short_addr_len, uint32_t sudt_id, uint128_t amount);
 
+/**
+ * Load value by raw key from state tree
+ *
+ * @param ctx        The godwoken context
+ * @param raw_key        The key (less than 32 bytes)
+ * @param key_len    The key length (less then 32)
+ * @param value      The pointer to save the value of the key (32 bytes)
+ * @return           The status code, 0 is success
+ */
+typedef int (*_gw_load_raw_fn)(struct gw_context_t *ctx,
+                          const uint8_t raw_key[GW_KEY_BYTES],
+                          uint8_t value[GW_VALUE_BYTES]);
+
+/**
+ * Store key,value pair to state tree
+ *
+ * @param ctx        The godwoken context
+ * @param account_id account to read
+ * @param key        The key (less than 32 bytes)
+ * @param key_len    The key length (less then 32)
+ * @param value      The value
+ * @return           The status code, 0 is success
+ */
+typedef int (*_gw_store_raw_fn)(struct gw_context_t *ctx,
+                           const uint8_t raw_key[GW_KEY_BYTES],
+                           const uint8_t value[GW_VALUE_BYTES]);
 #endif /* GW_DEF_H_ */

--- a/c/gw_smt.h
+++ b/c/gw_smt.h
@@ -1,4 +1,9 @@
-#include "common.h"
+#ifndef GW_SMT_H_
+#define GW_SMT_H_
+
+#include "gw_def.h"
+#include "gw_errors.h"
+#include "blake2b.h"
 
 #define _GW_SMT_STACK_SIZE 32
 
@@ -277,3 +282,5 @@ int gw_smt_verify(const uint8_t hash[32], const gw_state_t *state,
   }
   return 0;
 }
+
+#endif /* GW_SMT_H_ */

--- a/c/gw_syscalls.h
+++ b/c/gw_syscalls.h
@@ -1,8 +1,6 @@
 #ifndef GW_SYSCALLS_H_
 #define GW_SYSCALLS_H_
 
-#include "common.h"
-
 #ifdef GW_GENERATOR
 #include "generator_utils.h"
 #endif

--- a/tests/src/script_tests/l2_scripts/meta_contract.rs
+++ b/tests/src/script_tests/l2_scripts/meta_contract.rs
@@ -57,6 +57,7 @@ fn test_meta_contract() {
                 .build(),
         )
         .build();
+    let sender_nonce = tree.get_nonce(a_id).unwrap();
     let return_data = run_contract(
         &rollup_config,
         &mut tree,
@@ -66,6 +67,8 @@ fn test_meta_contract() {
         &block_info,
     )
     .expect("execute");
+    let new_sender_nonce = tree.get_nonce(a_id).unwrap();
+    assert_eq!(sender_nonce + 1, new_sender_nonce, "nonce should increased");
     let account_id = {
         let mut buf = [0u8; 4];
         buf.copy_from_slice(&return_data);

--- a/tests/src/script_tests/l2_scripts/sudt.rs
+++ b/tests/src/script_tests/l2_scripts/sudt.rs
@@ -103,6 +103,7 @@ fn test_sudt() {
     {
         let value = 4000u128;
         let fee = 42u128;
+        let sender_nonce = tree.get_nonce(a_id).unwrap();
         let args = SUDTArgs::new_builder()
             .set(
                 SUDTTransfer::new_builder()
@@ -121,6 +122,8 @@ fn test_sudt() {
             &block_info,
         )
         .expect("execute");
+        let new_sender_nonce = tree.get_nonce(a_id).unwrap();
+        assert_eq!(sender_nonce + 1, new_sender_nonce, "nonce increased");
         assert!(run_result.return_data.is_empty());
         assert_eq!(run_result.logs.len(), 2);
         check_transfer_logs(
@@ -359,6 +362,7 @@ fn test_transfer_to_self() {
     {
         let value: u128 = 0;
         let fee: u128 = 0;
+        let sender_nonce = tree.get_nonce(a_id).unwrap();
         let args = SUDTArgs::new_builder()
             .set(
                 SUDTTransfer::new_builder()
@@ -377,6 +381,8 @@ fn test_transfer_to_self() {
             &block_info,
         )
         .expect("run contract");
+        let new_sender_nonce = tree.get_nonce(a_id).unwrap();
+        assert_eq!(sender_nonce + 1, new_sender_nonce, "nonce increased");
         assert_eq!(run_result.logs.len(), 2);
         check_transfer_logs(
             &run_result.logs,

--- a/tests/src/testing_tool/chain.rs
+++ b/tests/src/testing_tool/chain.rs
@@ -3,7 +3,7 @@ use gw_block_producer::{
     produce_block::{produce_block, ProduceBlockParam, ProduceBlockResult},
     withdrawal::AvailableCustodians,
 };
-use gw_chain::chain::{Chain, L1Action, L1ActionContext, SyncEvent, SyncParam};
+use gw_chain::chain::{Chain, L1Action, L1ActionContext, SyncParam};
 use gw_common::H256;
 use gw_config::{BackendConfig, GenesisConfig};
 use gw_generator::{


### PR DESCRIPTION
Some backends such as Polyjuice EVM changes nonce in execution. To make best compatibility with those backends, instead update the nonce in godwoken, we let the backends to handling nonce.

Changes:

* Stop increase nonce for txs https://github.com/nervosnetwork/godwoken/pull/253, (we still need to handling nonce for withdrawals)
* Update the `gw_syscalls.h`, if the sender's nonce is not touched, we increase it by 1 in the gw_finalze callback.