### PR TITLE
Fix the `handle_fee` function in meta_contract

### DIFF
--- a/c/contracts/meta_contract.c
+++ b/c/contracts/meta_contract.c
@@ -8,7 +8,7 @@
 
 #include "ckb_syscalls.h"
 #include "gw_syscalls.h"
-#include "stdio.h"
+#include "sudt_utils.h"
 
 /* MSG_TYPE */
 #define MSG_CREATE_ACCOUNT 0
@@ -34,9 +34,9 @@ int handle_fee(gw_context_t *ctx, mol_seg_t fee_seg) {
   /* amount */
   mol_seg_t amount_seg = MolReader_Fee_get_amount(&fee_seg);
   uint128_t amount = *(uint128_t *)amount_seg.ptr;
-
-  return ctx->sys_pay_fee(ctx, payer_short_address, short_address_len, sudt_id,
-                          amount);
+  return sudt_pay_fee(ctx, sudt_id,
+                      short_address_len, payer_short_address,
+                      amount);
 }
 
 int main() {

--- a/tests/src/script_tests/l2_scripts/meta_contract.rs
+++ b/tests/src/script_tests/l2_scripts/meta_contract.rs
@@ -1,27 +1,32 @@
 use super::{new_block_info, run_contract};
 use crate::testing_tool::chain::META_VALIDATOR_SCRIPT_TYPE_HASH;
 use core::panic;
-use gw_common::state::State;
-use gw_common::H256;
+use gw_common::{
+    builtins::{CKB_SUDT_ACCOUNT_ID, RESERVED_ACCOUNT_ID},
+    state::State,
+    CKB_SUDT_SCRIPT_ARGS, H256,
+};
 use gw_generator::{
-    dummy_state::DummyState, error::TransactionError,
-    syscalls::error_codes::GW_ERROR_DUPLICATED_SCRIPT_HASH, traits::StateExt,
+    dummy_state::DummyState,
+    error::TransactionError,
+    syscalls::error_codes::{GW_ERROR_DUPLICATED_SCRIPT_HASH, GW_SUDT_ERROR_INSUFFICIENT_BALANCE},
+    traits::StateExt,
 };
 use gw_types::{
     core::ScriptHashType,
+    offchain::RollupContext,
     packed::{CreateAccount, MetaContractArgs, RollupConfig, Script},
     prelude::*,
 };
 
-#[test]
-fn test_meta_contract() {
-    let mut tree = DummyState::default();
-    let dummy_eoa_type_hash = [4u8; 32];
-    let rollup_config = RollupConfig::new_builder()
-        .allowed_eoa_type_hashes(vec![dummy_eoa_type_hash].pack())
-        .build();
-    // init accounts
-    let meta_contract_id = tree
+fn init_accounts(state: &mut DummyState, rollup_config: &RollupConfig) {
+    let rollup_context = RollupContext {
+        rollup_config: rollup_config.clone(),
+        rollup_script_hash: [42u8; 32].into(),
+    };
+
+    // setup meta_contract
+    let meta_contract_id = state
         .create_account_from_script(
             Script::new_builder()
                 .code_hash(META_VALIDATOR_SCRIPT_TYPE_HASH.clone().pack())
@@ -30,17 +35,38 @@ fn test_meta_contract() {
                 .build(),
         )
         .expect("create account");
-    assert_eq!(meta_contract_id, 0);
+    assert_eq!(meta_contract_id, RESERVED_ACCOUNT_ID);
 
+    // setup CKB simple UDT contract
+    let ckb_sudt_script =
+        gw_generator::sudt::build_l2_sudt_script(&rollup_context, &CKB_SUDT_SCRIPT_ARGS.into());
+    let ckb_sudt_id = state.create_account_from_script(ckb_sudt_script).unwrap();
+    assert_eq!(
+        ckb_sudt_id, CKB_SUDT_ACCOUNT_ID,
+        "ckb simple UDT account id"
+    );
+}
+
+#[test]
+fn test_meta_contract() {
+    let mut tree = DummyState::default();
+    let dummy_eoa_type_hash = [4u8; 32];
+    let rollup_config = RollupConfig::new_builder()
+        .allowed_eoa_type_hashes(vec![dummy_eoa_type_hash].pack())
+        .build();
+    init_accounts(&mut tree, &rollup_config);
+
+    let a_script = Script::new_builder()
+        .code_hash([0u8; 32].pack())
+        .args([0u8; 20].to_vec().pack())
+        .hash_type(ScriptHashType::Type.into())
+        .build();
+    let a_script_hash = a_script.hash();
     let a_id = tree
-        .create_account_from_script(
-            Script::new_builder()
-                .code_hash([0u8; 32].pack())
-                .args([0u8; 20].to_vec().pack())
-                .hash_type(ScriptHashType::Type.into())
-                .build(),
-        )
+        .create_account_from_script(a_script)
         .expect("create account");
+    tree.mint_sudt(CKB_SUDT_ACCOUNT_ID, &a_script_hash[..20], 2000)
+        .expect("mint CKB for account A to pay fee");
 
     let block_info = new_block_info(a_id, 1, 0);
 
@@ -50,10 +76,15 @@ fn test_meta_contract() {
         .hash_type(ScriptHashType::Type.into())
         .args([42u8; 33].pack())
         .build();
+    let fee_struct = gw_types::packed::Fee::new_builder()
+        .sudt_id(CKB_SUDT_ACCOUNT_ID.pack())
+        .amount(1000u128.pack())
+        .build();
     let args = MetaContractArgs::new_builder()
         .set(
             CreateAccount::new_builder()
                 .script(contract_script.clone())
+                .fee(fee_struct)
                 .build(),
         )
         .build();
@@ -62,7 +93,7 @@ fn test_meta_contract() {
         &rollup_config,
         &mut tree,
         a_id,
-        meta_contract_id,
+        RESERVED_ACCOUNT_ID,
         args.as_bytes(),
         &block_info,
     )
@@ -89,28 +120,19 @@ fn test_meta_contract() {
 fn test_duplicated_script_hash() {
     let mut tree = DummyState::default();
     let rollup_config = RollupConfig::default();
+    init_accounts(&mut tree, &rollup_config);
 
-    // init accounts
-    let meta_contract_id = tree
-        .create_account_from_script(
-            Script::new_builder()
-                .code_hash(META_VALIDATOR_SCRIPT_TYPE_HASH.clone().pack())
-                .args([0u8; 32].to_vec().pack())
-                .hash_type(ScriptHashType::Type.into())
-                .build(),
-        )
-        .expect("create account");
-    assert_eq!(meta_contract_id, 0);
-
+    let a_script = Script::new_builder()
+        .code_hash([0u8; 32].pack())
+        .args([0u8; 20].to_vec().pack())
+        .hash_type(ScriptHashType::Type.into())
+        .build();
+    let a_script_hash = a_script.hash();
     let a_id = tree
-        .create_account_from_script(
-            Script::new_builder()
-                .code_hash([0u8; 32].pack())
-                .args([0u8; 20].to_vec().pack())
-                .hash_type(ScriptHashType::Type.into())
-                .build(),
-        )
+        .create_account_from_script(a_script)
         .expect("create account");
+    tree.mint_sudt(CKB_SUDT_ACCOUNT_ID, &a_script_hash[..20], 1000)
+        .expect("mint CKB for account A to pay fee");
 
     let block_info = new_block_info(a_id, 1, 0);
 
@@ -126,10 +148,15 @@ fn test_duplicated_script_hash() {
         .expect("create account");
 
     // should return duplicated script hash
+    let fee_struct = gw_types::packed::Fee::new_builder()
+        .sudt_id(CKB_SUDT_ACCOUNT_ID.pack())
+        .amount(1000u128.pack())
+        .build();
     let args = MetaContractArgs::new_builder()
         .set(
             CreateAccount::new_builder()
                 .script(contract_script.clone())
+                .fee(fee_struct)
                 .build(),
         )
         .build();
@@ -137,7 +164,7 @@ fn test_duplicated_script_hash() {
         &rollup_config,
         &mut tree,
         a_id,
-        meta_contract_id,
+        RESERVED_ACCOUNT_ID,
         args.as_bytes(),
         &block_info,
     )
@@ -147,4 +174,91 @@ fn test_duplicated_script_hash() {
         err => panic!("unexpected {:?}", err),
     };
     assert_eq!(err_code, GW_ERROR_DUPLICATED_SCRIPT_HASH);
+}
+
+#[test]
+fn test_insufficient_balance_to_pay_fee() {
+    let mut state = DummyState::default();
+    let dummy_eoa_type_hash = [4u8; 32];
+    let rollup_config = RollupConfig::new_builder()
+        .allowed_eoa_type_hashes(vec![dummy_eoa_type_hash].pack())
+        .build();
+    init_accounts(&mut state, &rollup_config);
+
+    let from_script = Script::new_builder()
+        .code_hash([0u8; 32].pack())
+        .args([0u8; 20].to_vec().pack())
+        .hash_type(ScriptHashType::Type.into())
+        .build();
+    let from_script_hash = from_script.hash();
+    let from_id = state
+        .create_account_from_script(from_script)
+        .expect("create account");
+
+    // create contract
+    let contract_script = Script::new_builder()
+        .code_hash(dummy_eoa_type_hash.pack())
+        .hash_type(ScriptHashType::Type.into())
+        .args([42u8; 52].pack())
+        .build();
+    let fee_struct = gw_types::packed::Fee::new_builder()
+        .sudt_id(CKB_SUDT_ACCOUNT_ID.pack())
+        .amount(1000u128.pack())
+        .build();
+    let args = MetaContractArgs::new_builder()
+        .set(
+            CreateAccount::new_builder()
+                .script(contract_script.clone())
+                .fee(fee_struct)
+                .build(),
+        )
+        .build();
+    let err = run_contract(
+        &rollup_config,
+        &mut state,
+        from_id,
+        RESERVED_ACCOUNT_ID,
+        args.as_bytes(),
+        &new_block_info(from_id, 1, 0),
+    )
+    .unwrap_err();
+    let err_code = match err {
+        TransactionError::InvalidExitCode(code) => code,
+        err => panic!("unexpected {:?}", err),
+    };
+    assert_eq!(
+        err_code,
+        gw_generator::syscalls::error_codes::GW_SUDT_ERROR_INSUFFICIENT_BALANCE
+    );
+
+    state
+        .mint_sudt(CKB_SUDT_ACCOUNT_ID, &from_script_hash[..20], 999)
+        .expect("mint CKB for account A to pay fee");
+    let err = run_contract(
+        &rollup_config,
+        &mut state,
+        from_id,
+        RESERVED_ACCOUNT_ID,
+        args.as_bytes(),
+        &new_block_info(from_id, 2, 0),
+    )
+    .unwrap_err();
+    let err_code = match err {
+        TransactionError::InvalidExitCode(code) => code,
+        err => panic!("unexpected {:?}", err),
+    };
+    assert_eq!(err_code, GW_SUDT_ERROR_INSUFFICIENT_BALANCE);
+
+    state
+        .mint_sudt(CKB_SUDT_ACCOUNT_ID, &from_script_hash[..20], 1000)
+        .expect("mint CKB for account A to pay fee");
+    let _return_data = run_contract(
+        &rollup_config,
+        &mut state,
+        from_id,
+        RESERVED_ACCOUNT_ID,
+        args.as_bytes(),
+        &new_block_info(from_id, 3, 0),
+    )
+    .expect("contract created successful");
 }


### PR DESCRIPTION
The `sys_pay_fee` syscall only records the fee to block producer, misses tranfer operation.
The `handle_fee` function should call `sudt_pay_fee` instead of `sys_pay_fee`.