### PR TITLE
build: stick capsule docker image version

### DIFF
--- a/capsule.toml
+++ b/capsule.toml
@@ -3,6 +3,7 @@ deployment = "deployment.toml"
 [rust]
 workspace_dir = "contracts"
 toolchain = "nightly-2021-08-16"
+docker_image = "thewawar/ckb-capsule:2021-08-16"
 
 [[contracts]]
 name = "state-validator"


### PR DESCRIPTION
Otherwise, `capsule build` will not work when docker image version updated.