### PR TITLE
refactor(gw_get_script_hash_by_prefix_fn): use `const` for `prefix` arg

### DIFF
--- a/c/common.h
+++ b/c/common.h
@@ -76,7 +76,7 @@ void gw_build_data_hash_key(uint8_t data_hash[GW_KEY_BYTES],
 }
 
 int gw_build_short_script_hash_to_script_hash_key(
-    uint8_t *short_script_hash, uint32_t short_script_hash_len,
+    const uint8_t *short_script_hash, uint32_t short_script_hash_len,
     uint8_t raw_key[GW_KEY_BYTES]) {
   if (short_script_hash_len > 32 || short_script_hash == NULL) {
     return GW_FATAL_INVALID_DATA;
@@ -267,7 +267,7 @@ int _check_data_hash_exist(gw_context_t *ctx, uint8_t data_hash[32],
 }
 
 int _load_script_hash_by_short_script_hash(gw_context_t *ctx,
-                                           uint8_t *short_script_hash,
+                                           const uint8_t *short_script_hash,
                                            uint32_t short_script_hash_len,
                                            uint8_t script_hash[32]) {
   if (ctx == NULL) {

--- a/c/generator_utils.h
+++ b/c/generator_utils.h
@@ -296,7 +296,7 @@ int sys_get_block_hash(gw_context_t *ctx, uint64_t number,
   return syscall(GW_SYS_GET_BLOCK_HASH, block_hash, number, 0, 0, 0, 0);
 }
 
-int sys_get_script_hash_by_prefix(gw_context_t *ctx, uint8_t *prefix,
+int sys_get_script_hash_by_prefix(gw_context_t *ctx, const uint8_t *prefix,
                                   uint64_t prefix_len,
                                   uint8_t script_hash[32]) {
   if (ctx == NULL) {

--- a/c/gw_def.h
+++ b/c/gw_def.h
@@ -204,7 +204,7 @@ typedef int (*gw_get_block_hash_fn)(struct gw_context_t *ctx, uint64_t number,
  * @return            The status code, 0 is success
  */
 typedef int (*gw_get_script_hash_by_prefix_fn)(struct gw_context_t *ctx,
-                                               uint8_t *prefix,
+                                               const uint8_t *prefix,
                                                uint64_t prefix_len,
                                                uint8_t script_hash[32]);
 /**

--- a/c/validator_utils.h
+++ b/c/validator_utils.h
@@ -452,7 +452,7 @@ int sys_get_block_hash(gw_context_t *ctx, uint64_t number,
   return 0;
 }
 
-int sys_get_script_hash_by_prefix(gw_context_t *ctx, uint8_t *prefix,
+int sys_get_script_hash_by_prefix(gw_context_t *ctx, const uint8_t *prefix,
                                   uint64_t prefix_len,
                                   uint8_t script_hash[32]) {
   if (ctx == NULL) {


### PR DESCRIPTION
- fix error: invalid conversion 
```
from 'int (*)(gw_context_t*, const uint8_t*, uint64_t, uint8_t*)' {aka 'int (*)(gw_context_t*, const unsigned char*, long unsigned int, unsigned char*)'} to 'gw_get_script_hash_by_prefix_fn' {aka 'int (*)(gw_context_t*, unsigned char*, long unsigned int, unsigned char*)'} [-fpermissive]
   ctx->sys_get_script_hash_by_prefix = sys_get_script_hash_by_prefix;
                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~

c/tests/../generator/../polyjuice_utils.h:156:51: error: invalid conversion from 'const uint8_t*' {aka 'const unsigned char*'} to 'uint8_t*' {aka 'unsigned char*'} [-fpermissive]
     ret = ctx->sys_get_script_hash_by_prefix(ctx, eth_address,
```