### PR TITLE
feat: add overwrite param when update eth addr reg

### DIFF
--- a/c/gw_eth_addr_reg.h
+++ b/c/gw_eth_addr_reg.h
@@ -75,20 +75,19 @@ int gw_update_eth_address_register(
 /**
  * @brief Remove mapping from script hash to eth reg addr by setting value to
  * zero-hash.
- * 
- * @param ctx 
+ *
+ * @param ctx
  * @param script_hash which is going to be removed
  * @return 0 if successful
  */
 int gw_rm_script_hash_to_eth_addr_reg(
-    gw_context_t *ctx,
-    const uint8_t script_hash[GW_VALUE_BYTES]) {
+    gw_context_t *ctx, const uint8_t script_hash[GW_VALUE_BYTES]) {
   uint8_t script_hash_to_eth_key[36] = {0};
   _gw_build_script_hash_to_registry_address_key(script_hash_to_eth_key,
                                                 (uint8_t *)script_hash);
   uint8_t addr_buf[32] = {0};
   int ret = ctx->sys_store(ctx, GW_DEFAULT_ETH_REGISTRY_ACCOUNT_ID,
-                       script_hash_to_eth_key, 36, addr_buf);
+                           script_hash_to_eth_key, 36, addr_buf);
   if (ret != 0) {
     return ret;
   }

--- a/c/gw_eth_addr_reg.h
+++ b/c/gw_eth_addr_reg.h
@@ -73,6 +73,30 @@ int gw_update_eth_address_register(
 }
 
 /**
+ * @brief Remove mapping from script hash to eth reg addr by setting value to
+ * zero-hash.
+ * 
+ * @param ctx 
+ * @param script_hash which is going to be removed
+ * @return 0 if successful
+ */
+int gw_rm_script_hash_to_eth_addr_reg(
+    gw_context_t *ctx,
+    const uint8_t script_hash[GW_VALUE_BYTES]) {
+  uint8_t script_hash_to_eth_key[36] = {0};
+  _gw_build_script_hash_to_registry_address_key(script_hash_to_eth_key,
+                                                (uint8_t *)script_hash);
+  uint8_t addr_buf[32] = {0};
+  int ret = ctx->sys_store(ctx, GW_DEFAULT_ETH_REGISTRY_ACCOUNT_ID,
+                       script_hash_to_eth_key, 36, addr_buf);
+  if (ret != 0) {
+    return ret;
+  }
+
+  return 0;
+}
+
+/**
  * @brief register an account into `ETH Address Registry` by its script_hash
  *
  * Option 1: ETH EOA (externally owned account)

--- a/c/gw_eth_addr_reg.h
+++ b/c/gw_eth_addr_reg.h
@@ -44,6 +44,19 @@ int gw_update_eth_address_register(
     return GW_REGISTRY_ERROR_DUPLICATE_MAPPING;
   }
 
+  /* clear old mapping */
+  if (ret == 0 && overwrite) {
+    uint8_t script_hash_to_eth_key[36] = {0};
+    _gw_build_script_hash_to_registry_address_key(script_hash_to_eth_key,
+                                                  (uint8_t *)_buf);
+    uint8_t zero_value[32] = {0};
+    int ret = ctx->sys_store(ctx, GW_DEFAULT_ETH_REGISTRY_ACCOUNT_ID,
+                             script_hash_to_eth_key, 36, zero_value);
+    if (ret != 0) {
+      return ret;
+    }
+  }
+
   /* eth_address -> gw_script_hash */
   uint8_t eth_to_script_hash_key[32] = {0};
   ret = _gw_build_registry_address_to_script_hash_key(eth_to_script_hash_key,
@@ -65,29 +78,6 @@ int gw_update_eth_address_register(
   _gw_cpy_addr(addr_buf, addr);
   ret = ctx->sys_store(ctx, GW_DEFAULT_ETH_REGISTRY_ACCOUNT_ID,
                        script_hash_to_eth_key, 36, addr_buf);
-  if (ret != 0) {
-    return ret;
-  }
-
-  return 0;
-}
-
-/**
- * @brief Remove mapping from script hash to eth reg addr by setting value to
- * zero-hash.
- *
- * @param ctx
- * @param script_hash which is going to be removed
- * @return 0 if successful
- */
-int gw_rm_script_hash_to_eth_addr_reg(
-    gw_context_t *ctx, const uint8_t script_hash[GW_VALUE_BYTES]) {
-  uint8_t script_hash_to_eth_key[36] = {0};
-  _gw_build_script_hash_to_registry_address_key(script_hash_to_eth_key,
-                                                (uint8_t *)script_hash);
-  uint8_t addr_buf[32] = {0};
-  int ret = ctx->sys_store(ctx, GW_DEFAULT_ETH_REGISTRY_ACCOUNT_ID,
-                           script_hash_to_eth_key, 36, addr_buf);
   if (ret != 0) {
     return ret;
   }

--- a/c/gw_eth_addr_reg.h
+++ b/c/gw_eth_addr_reg.h
@@ -17,11 +17,12 @@
  * 1. Externally-owned – controlled by anyone with the private keys
  * 2. Contract – a smart contract deployed to the network, controlled by code
  * @param script_hash Godwoken account script hash
+ * @param overwrite re-map if the account has been registered
  * @return int: 0 means success
  */
 int gw_update_eth_address_register(
     gw_context_t *ctx, const uint8_t eth_address[GW_ETH_ADDRESS_LEN],
-    const uint8_t script_hash[GW_VALUE_BYTES]) {
+    const uint8_t script_hash[GW_VALUE_BYTES], bool overwrite) {
   if (ctx == NULL) {
     return GW_FATAL_INVALID_CONTEXT;
   }
@@ -39,7 +40,7 @@ int gw_update_eth_address_register(
   /* check if the account has been registered */
   uint8_t _buf[32] = {0};
   int ret = ctx->sys_get_script_hash_by_registry_address(ctx, &addr, _buf);
-  if (ret == 0) {
+  if (ret == 0 && !overwrite) {
     return GW_REGISTRY_ERROR_DUPLICATE_MAPPING;
   }
 
@@ -160,7 +161,8 @@ int gw_register_eth_address(gw_context_t *ctx,
         }
         _gw_fast_memcpy(eth_address, raw_bytes_seg.ptr + 32,
                         GW_ETH_ADDRESS_LEN);
-        return gw_update_eth_address_register(ctx, eth_address, script_hash);
+        return gw_update_eth_address_register(ctx, eth_address, script_hash,
+                                              false);
       }
     }
   }
@@ -214,7 +216,8 @@ int gw_register_eth_address(gw_context_t *ctx,
         }
         _gw_fast_memcpy(eth_address, raw_bytes_seg.ptr + 36,
                         GW_ETH_ADDRESS_LEN);
-        return gw_update_eth_address_register(ctx, eth_address, script_hash);
+        return gw_update_eth_address_register(ctx, eth_address, script_hash,
+                                              false);
       }
     }
   }


### PR DESCRIPTION
Add `overwrite` param when updating mapping between eth addr and script hash. So that we can choose to overwrite mapping or not if there is an address collision.