### PR TITLE
chore: check CKB_SUDT_SCRIPT_ARGS in build_l2_sudt_script

### DIFF
--- a/contracts/gw-utils/src/cells/utils.rs
+++ b/contracts/gw-utils/src/cells/utils.rs
@@ -3,7 +3,7 @@ use ckb_std::{
     ckb_constants::Source,
     high_level::{load_cell_lock_hash, QueryIter},
 };
-use gw_common::H256;
+use gw_common::{CKB_SUDT_SCRIPT_ARGS, H256};
 use gw_types::{
     bytes::Bytes,
     core::ScriptHashType,
@@ -32,16 +32,21 @@ pub fn build_l2_sudt_script(
     rollup_script_hash: &H256,
     config: &RollupConfig,
     l1_sudt_script_hash: &H256,
-) -> Script {
+) -> Option<Script> {
+    if l1_sudt_script_hash == &CKB_SUDT_SCRIPT_ARGS.into() {
+        return None;
+    }
     let args = {
         let mut args = Vec::with_capacity(64);
         args.extend(rollup_script_hash.as_slice());
         args.extend(l1_sudt_script_hash.as_slice());
         Bytes::from(args)
     };
-    Script::new_builder()
-        .args(args.pack())
-        .code_hash(config.l2_sudt_validator_script_type_hash())
-        .hash_type(ScriptHashType::Type.into())
-        .build()
+    Some(
+        Script::new_builder()
+            .args(args.pack())
+            .code_hash(config.l2_sudt_validator_script_type_hash())
+            .hash_type(ScriptHashType::Type.into())
+            .build(),
+    )
 }


### PR DESCRIPTION
Check `l1_sudt_script_hash == CKB_SUDT_SCRIPT_ARGS` in `build_l2_sudt_script` to prevent build the CKB SUDT script accidentally.