### PR TITLE
chore: remove redundant checking of post account state

### DIFF
--- a/contracts/state-validator/src/verifications/submit_block.rs
+++ b/contracts/state-validator/src/verifications/submit_block.rs
@@ -612,29 +612,6 @@ fn check_block_transactions(block: &L2BlockReader, kv_state: &KVState) -> Result
         return Err(Error::InvalidStateCheckpoint);
     }
 
-    // check post account tree state
-    let last_checkpoint_root = if block.transactions().is_empty() {
-        prev_state_checkpoint
-    } else {
-        raw_block
-            .state_checkpoint_list()
-            .iter()
-            .last()
-            .map(|checkpoint| checkpoint.unpack())
-            .ok_or(Error::InvalidStateCheckpoint)?
-    };
-    let block_post_state_root = {
-        let account = raw_block.post_account();
-        calculate_state_checkpoint(&account.merkle_root().unpack(), account.count().unpack())
-    };
-    if last_checkpoint_root != block_post_state_root {
-        debug!(
-            "Invalid post state, last_checkpoint_root: {:?}, block_post_state_root: {:?}",
-            last_checkpoint_root, block_post_state_root
-        );
-        return Err(Error::InvalidStateCheckpoint);
-    }
-
     Ok(())
 }
 


### PR DESCRIPTION
RawL2Block's post account state is already checked in [`check_state_checkpoints`](https://github.com/nervosnetwork/godwoken-scripts/blob/b61b7351d75c409c723dbda0a48988ea554d3c17/contracts/state-validator/src/verifications/submit_block.rs#L550-L574). So I remove one of them.

- `check_state_checkpoints`: https://github.com/nervosnetwork/godwoken-scripts/blob/b61b7351d75c409c723dbda0a48988ea554d3c17/contracts/state-validator/src/verifications/submit_block.rs#L550-L574


- `check_block_transactions`: https://github.com/nervosnetwork/godwoken-scripts/blob/b61b7351d75c409c723dbda0a48988ea554d3c17/contracts/state-validator/src/verifications/submit_block.rs#L615-L636